### PR TITLE
3 create markgranted and markwishing capability

### DIFF
--- a/controllers/wishes.js
+++ b/controllers/wishes.js
@@ -9,9 +9,8 @@ module.exports = {
         catch(err){
             console.log(err)
         }
-       
-
     },
+
     makeWish: async(req,res) =>{
         try{
             await Wish.create({
@@ -28,12 +27,31 @@ module.exports = {
         }
         
     },
+
     markGranted: async(req,res) =>{
-
+        try {
+            await Wish.findOneAndUpdate({ __id:req.body.wishIdFromJSFile}, {
+                purchased: true
+            })
+            console.log('Wish Granted!')
+            res.json('Wish Granted!')
+        } catch(err) {
+            console.log(err)
+        }
     },
+
     markWishing: async(req,res) =>{
-
+        try {
+            await Wish.findOneAndUpdate({__id:req.body.wishIdFromJSFile}, {
+                purchased: false
+            })
+            console.log('Wish Unfulfilled!')
+            res.json('Wish Unfulfilled!')
+        } catch(err) {
+            console.log(err)
+        }
     },
+    
     deleteWish: async(req,res) =>{
 
     },

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -31,7 +31,7 @@ Array.from(todoComplete).forEach((el)=>{
 async function deleteWish(){
     const wishId = this.parentNode.dataset.id
     try{
-        const response = await fetch('todos/deleteWish', {
+        const response = await fetch('wishes/deleteWish', {
             method: 'delete',
             headers: {'Content-type': 'application/json'},
             body: JSON.stringify({
@@ -49,7 +49,7 @@ async function deleteWish(){
 async function markGranted(){
     const wishId = this.parentNode.dataset.id
     try{
-        const response = await fetch('todos/markGranted', {
+        const response = await fetch('wishes/markGranted', {
             method: 'put',
             headers: {'Content-type': 'application/json'},
             body: JSON.stringify({
@@ -67,7 +67,7 @@ async function markGranted(){
 async function markWishing(){
     const wishId = this.parentNode.dataset.id
     try{
-        const response = await fetch('todos/markWishing', {
+        const response = await fetch('wishes/markWishing', {
             method: 'put',
             headers: {'Content-type': 'application/json'},
             body: JSON.stringify({

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -1,27 +1,41 @@
 const deleteBtn = document.querySelectorAll('.del')
+const wishItem = document.querySelectorAll('span.not')
+const wishGranted = document.querySelectorAll('span.granted')
+
+//Delete both of these when transitioned from todos to wishes:
 const todoItem = document.querySelectorAll('span.not')
 const todoComplete = document.querySelectorAll('span.completed')
 
+
 Array.from(deleteBtn).forEach((el)=>{
-    el.addEventListener('click', deleteTodo)
+    el.addEventListener('click', deleteWish)
 })
 
+Array.from(wishItem).forEach((el) => {
+    el.addEventListener('click', markGranted)
+})
+
+Array.from(wishGranted).forEach((el) => {
+    el.addEventListener('click', markWishing)
+})
+
+//Delete both of these Arrays/listeners when transitioned from todos to wishes:
 Array.from(todoItem).forEach((el)=>{
     el.addEventListener('click', markComplete)
 })
-
 Array.from(todoComplete).forEach((el)=>{
     el.addEventListener('click', markIncomplete)
 })
 
-async function deleteTodo(){
-    const todoId = this.parentNode.dataset.id
+
+async function deleteWish(){
+    const wishId = this.parentNode.dataset.id
     try{
-        const response = await fetch('todos/deleteTodo', {
+        const response = await fetch('todos/deleteWish', {
             method: 'delete',
             headers: {'Content-type': 'application/json'},
             body: JSON.stringify({
-                'todoIdFromJSFile': todoId
+                'wishIdFromJSFile': wishId
             })
         })
         const data = await response.json()
@@ -31,6 +45,46 @@ async function deleteTodo(){
         console.log(err)
     }
 }
+
+async function markGranted(){
+    const wishId = this.parentNode.dataset.id
+    try{
+        const response = await fetch('todos/markGranted', {
+            method: 'put',
+            headers: {'Content-type': 'application/json'},
+            body: JSON.stringify({
+                'wishIdFromJSFile': wishId
+            })
+        })
+        const data = await response.json()
+        console.log(data)
+        location.reload()
+    }catch(err){
+        console.log(err)
+    }
+}
+
+async function markWishing(){
+    const wishId = this.parentNode.dataset.id
+    try{
+        const response = await fetch('todos/markWishing', {
+            method: 'put',
+            headers: {'Content-type': 'application/json'},
+            body: JSON.stringify({
+                'wishIdFromJSFile': wishId
+            })
+        })
+        const data = await response.json()
+        console.log(data)
+        location.reload()
+    }catch(err){
+        console.log(err)
+    }
+}
+
+//
+// Delete below this line when we have transitioned to wishes:
+//
 
 async function markComplete(){
     const todoId = this.parentNode.dataset.id


### PR DESCRIPTION
This merge won't completely add wish functionality to the site, but the backend for these two actions should be.... mostly done?

controllers/wishes.js was updated to add the markGranted and markWishing async functions. They should communicate with the database to alternately label a given wish as purchased or not purchased (aka granted or unfulfilled, in common wish language).

public/js/main.js was updated to both create the event listeners for each item in the list, and to add the functions for markGranted and markWishing. I added comments about which lines to remove later once the todos are completely removed.

None of this makes the wishing/unwishing thing functional - someone will need to add the connections to the frontend I think.